### PR TITLE
Fixed typo in pam_appl.h and modified pam_modules.h test

### DIFF
--- a/libpam/configure.ac
+++ b/libpam/configure.ac
@@ -13,7 +13,14 @@ AC_PROG_CC_STDC
 AC_CHECK_HEADERS([sys/fsuid.h])
 AC_CHECK_FUNCS([setfsuid])
 
-AC_CHECK_HEADERS_ONCE([security/pam_modules.h security/pam_aapl.h])
+AC_CHECK_HEADERS_ONCE([security/pam_appl.h])
+# On Solaris at least, <secutiy/pam_modules.h> requires <security/pam_appl.h>
+# to be included first
+AC_CHECK_HEADER([security/pam_modules.h], [], [], \
+		[#ifdef HAVE_SECURITY_PAM_APPL_H
+		# include <security/pam_appl.h>
+		#endif
+		])
 AC_CHECK_LIB([pam], [pam_get_user], [:])
 AS_IF([test "x$ac_cv_header_security_pam_modules_h" = "xno" \
        -o "x$ac_cv_lib_pam_pam_get_user" = "xno"], [


### PR DESCRIPTION
On Solaris (and derived) platforms, <security/pam_appl.h> must be included before <security/pam_modules.h>.  On other platforms, #including <security/pam_appl.h> should never hurt, so this should allow the check to succeed on more platforms.