### PR TITLE
Add -lpam when linking pam_google_authenticator module to fix undefined symbol problem

### DIFF
--- a/libpam/Makefile.am
+++ b/libpam/Makefile.am
@@ -49,6 +49,7 @@ hmac.c \
 hmac.h \
 sha1.c \
 sha1.h
+pam_google_authenticator_la_LIBADD = -lpam
 pam_google_authenticator_la_CFLAGS=$(AM_CFLAGS)
 pam_google_authenticator_la_LDFLAGS=$(AM_LDFLAGS) $(MODULES_LDFLAGS) -export-symbols-regex "pam_sm_(setcred|open_session|authenticate)"
 


### PR DESCRIPTION
As part of the autotools migration, the -lpam option was lost, bringing back issue #81.
Add -lpam to pam_google_authenticator_la_LIBADD in Makefile.am to fix this again.