### PR TITLE
Remove m4 addition to ACLOCAL_AMFLAGS and add more files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,11 @@ libpam/*.la
 libpam/*.lo
 libpam/*.o
 libpam/pam_google_authenticator_unittest
+libpam/pam_google_authenticator_unittest.log
+libpam/pam_google_authenticator_unittest.trs
 libpam/stamp-h1
 libpam/test-driver
+libpam/test-suite.log
 mobile/blackberry/bin/
 mobile/blackberry/build/
 mobile/blackberry/deliverables/

--- a/libpam/Makefile.am
+++ b/libpam/Makefile.am
@@ -8,8 +8,6 @@ check_LTLIBRARIES=libpam_google_authenticator_testing.la
 dist_doc_DATA = FILEFORMAT README
 dist_html_DATA = totp.html
 
-ACLOCAL_AMFLAGS = -I m4
-
 MODULES_LDFLAGS = -avoid-version -module -shared -export-dynamic
 
 demo_SOURCES=\


### PR DESCRIPTION
* Older versions of autoreconf don't run libtoolize correctly, and even
  newer versions can run aclocal before libtoolize, which fails due to
  a non-existing 'm4' directory. Revert previous addition of 'm4' to
  ACLOCAL_AMFLAGS and just live with the warning (until any local .m4
  files need to be added to the project).
* Add test-suite related files to .gitignore