### PR TITLE
Fix SIGSEGV in pam_google_authenticator.c

### DIFF
--- a/libpam/pam_google_authenticator.c
+++ b/libpam/pam_google_authenticator.c
@@ -884,7 +884,7 @@ static int check_scratch_codes(pam_handle_t *pamh,
 
   // No scratch code has been used. Continue checking other types of codes.
   if(params->debug) {
-    log_message(LOG_INFO, pamh, "debug: no scratch code used from \"%s\"", code, secret_filename);
+    log_message(LOG_INFO, pamh, "debug: no scratch code used from \"%s\"", secret_filename);
   }
   return 1;
 }


### PR DESCRIPTION
When running in debug mode the extra "code" parameter to log_message can cause a SIGSEGV. Removing the incorrect parameter appears to solve the issue.