### PR TITLE
Add Travis CI for testing commits to libpam

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+compiler:
+  - clang
+  - gcc
+script: cd libpam && ./bootstrap.sh && ./configure && make && make check
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libpam0g-dev libqrencode3

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/google/google-authenticator.svg?branch=master)](https://travis-ci.org/google/google-authenticator)
+
 The Google Authenticator project includes implementations of one-time passcode
 generators for several mobile platforms, as well as a pluggable authentication
 module (PAM). One-time passcodes are generated using open standards developed by


### PR DESCRIPTION
This adds basic testing of every PR and commit to libpam. Useful for ensuring things committed actually compile and pass the unit tests.

Note that in order for this to work, a repository admin needs to perform steps one and two as listed on http://docs.travis-ci.com/user/getting-started/. Pretty simple overall.

You can see this in action [here](https://travis-ci.org/reedloden/google-authenticator/builds/59168711).