### PR TITLE
fix memory leak in write_file_contents() (libpam)

### DIFF
--- a/libpam/pam_google_authenticator.c
+++ b/libpam/pam_google_authenticator.c
@@ -440,6 +440,7 @@ static int write_file_contents(pam_handle_t *pamh,
   int fd = open(tmp_filename,
                 O_WRONLY|O_CREAT|O_NOFOLLOW|O_TRUNC|O_EXCL, 0400);
   if (fd < 0) {
+    free(tmp_filename);
     goto removal_failure;
   }
 


### PR DESCRIPTION
add missing deallocation of the temporary file name on failure to open the file.

This fixes google/google-authenticator#200