### PR TITLE
WillGenerateNewOTPWarningNotification bug fix

### DIFF
--- a/mobile/ios/Classes/OTPAuthURL.m
+++ b/mobile/ios/Classes/OTPAuthURL.m
@@ -431,7 +431,8 @@ static NSString *const TOTPAuthURLTimerNotification
     [nc postNotificationName:OTPAuthURLDidGenerateNewOTPNotification object:self];
     self.lastProgress = period;
     self.warningSent = NO;
-  } else if (progress > period - self.generationAdvanceWarning
+  }
+ if (progress > period - self.generationAdvanceWarning
              && !self.warningSent) {
     NSNumber *warning = [NSNumber numberWithInt:ceil(period - progress)];
     NSDictionary *userInfo


### PR DESCRIPTION
OTPAuthURLWillGenerateNewOTPWarningNotification would never get posted. The first part of the if statement will always be true so the else if would never get evaluated.