### PR TITLE
Improved Solaris support

### DIFF
--- a/libpam/configure.ac
+++ b/libpam/configure.ac
@@ -34,9 +34,16 @@ AC_LANG_PUSH(C)
 AC_LANG_WERROR
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 	#include <security/pam_appl.h>
+	#include <security/pam_modules.h>
 ]],[[
 	const void **item;
-	(void) pam_get_item(NULL, 0, item);
+	int dummy = 0;
+	/*
+	 * since pam_handle_t is opaque on at least some platforms, give it
+	 * a non-NULL dummy value
+	 */
+	 const pam_handle_t *ph = (const pam_handle_t *)&dummy;
+	(void) pam_get_item(ph, 0, item);
 ]])],[AC_DEFINE([PAM_CONST], [const], \
 		[Define if certain PAM functions require const arguments])
       AC_MSG_RESULT([yes])],

--- a/libpam/configure.ac
+++ b/libpam/configure.ac
@@ -28,6 +28,22 @@ AS_IF([test "x$ac_cv_header_security_pam_modules_h" = "xno" \
   AC_MSG_ERROR([Unable to find the PAM library or the PAM header files])
 ])
 
+AC_MSG_CHECKING([whether certain PAM functions require const arguments])
+AC_LANG_PUSH(C)
+# Force test to bail if const isn't needed
+AC_LANG_WERROR
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+	#include <security/pam_appl.h>
+]],[[
+	const void **item;
+	(void) pam_get_item(NULL, 0, item);
+]])],[AC_DEFINE([PAM_CONST], [const], \
+		[Define if certain PAM functions require const arguments])
+      AC_MSG_RESULT([yes])],
+     [AC_DEFINE([PAM_CONST], [], \
+		[Prevent certain PAM functions from using const arguments])
+      AC_MSG_RESULT([no])])
+AC_LANG_POP(C)
 
 AC_SEARCH_LIBS([dlopen], [dl])
 

--- a/libpam/configure.ac
+++ b/libpam/configure.ac
@@ -1,5 +1,6 @@
 AC_PREREQ(2.61)
 AC_INIT(google-authenticator, 1.01, habets@google.com)
+AC_USE_SYSTEM_EXTENSIONS
 LT_INIT
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([google-authenticator.c])

--- a/libpam/demo.c
+++ b/libpam/demo.c
@@ -15,6 +15,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+#include "config.h"
 
 #include <assert.h>
 #include <fcntl.h>
@@ -40,7 +42,7 @@ static struct termios old_termios;
 static int jmpbuf_valid;
 static sigjmp_buf jmpbuf;
 
-static int conversation(int num_msg, const struct pam_message **msg,
+static int conversation(int num_msg, PAM_CONST struct pam_message **msg,
                         struct pam_response **resp, void *appdata_ptr) {
   if (num_msg == 1 &&
       (msg[0]->msg_style == PAM_PROMPT_ECHO_OFF ||
@@ -80,11 +82,12 @@ static int conversation(int num_msg, const struct pam_message **msg,
 #else
 #define PAM_CONST const
 #endif
+
 int pam_get_item(const pam_handle_t *pamh, int item_type,
                  PAM_CONST void **item) {
   switch (item_type) {
     case PAM_SERVICE: {
-      static const char *service = "google_authenticator_demo";
+      static const char service[] = "google_authenticator_demo";
       memcpy(item, &service, sizeof(&service));
       return PAM_SUCCESS;
     }
@@ -104,7 +107,7 @@ int pam_get_item(const pam_handle_t *pamh, int item_type,
 }
 
 int pam_set_item(pam_handle_t *pamh, int item_type,
-                 PAM_CONST void *item) {
+                 const void *item) {
   switch (item_type) {
     case PAM_AUTHTOK:
       return PAM_SUCCESS;

--- a/libpam/google-authenticator.c
+++ b/libpam/google-authenticator.c
@@ -18,8 +18,6 @@
 
 #include "config.h"
 
-#define _GNU_SOURCE
-
 #include <assert.h>
 #include <errno.h>
 #include <dlfcn.h>

--- a/libpam/google-authenticator.c
+++ b/libpam/google-authenticator.c
@@ -16,6 +16,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "config.h"
+
 #define _GNU_SOURCE
 
 #include <assert.h>

--- a/libpam/pam_google_authenticator.c
+++ b/libpam/pam_google_authenticator.c
@@ -16,7 +16,6 @@
 // limitations under the License.
 #include "config.h"
 
-#define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>

--- a/libpam/pam_google_authenticator.c
+++ b/libpam/pam_google_authenticator.c
@@ -111,7 +111,7 @@ static void log_message(int priority, pam_handle_t *pamh,
 }
 
 static int converse(pam_handle_t *pamh, int nargs,
-                    const struct pam_message **message,
+                    PAM_CONST struct pam_message **message,
                     struct pam_response **response) {
   struct pam_conv *conv;
   int retval = pam_get_item(pamh, PAM_CONV, (void *)&conv);
@@ -821,7 +821,7 @@ static int rate_limit(pam_handle_t *pamh, const char *secret_filename,
 }
 
 static char *get_first_pass(pam_handle_t *pamh) {
-  const void *password = NULL;
+  PAM_CONST void *password = NULL;
   if (pam_get_item(pamh, PAM_AUTHTOK, &password) == PAM_SUCCESS &&
       password) {
     return strdup((const char *)password);
@@ -830,11 +830,11 @@ static char *get_first_pass(pam_handle_t *pamh) {
 }
 
 static char *request_pass(pam_handle_t *pamh, int echocode,
-                          const char *prompt) {
+                          PAM_CONST char *prompt) {
   // Query user for verification code
-  const struct pam_message msg = { .msg_style = echocode,
+  PAM_CONST struct pam_message msg = { .msg_style = echocode,
                                    .msg       = prompt };
-  const struct pam_message *msgs = &msg;
+  PAM_CONST struct pam_message *msgs = &msg;
   struct pam_response *resp = NULL;
   int retval = converse(pamh, 1, &msgs, &resp);
   char *ret = NULL;
@@ -1232,7 +1232,7 @@ static int check_timebased_code(pam_handle_t *pamh, const char*secret_filename,
   }
 
   // Compute verification codes and compare them with user input
-  const int tm = get_timestamp(pamh, secret_filename, buf);
+  const int tm = get_timestamp(pamh, secret_filename, (const char **)buf);
   if (!tm) {
     return -1;
   }

--- a/libpam/pam_google_authenticator_unittest.c
+++ b/libpam/pam_google_authenticator_unittest.c
@@ -15,6 +15,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include "config.h"
 
 #include <assert.h>
 #include <dlfcn.h>
@@ -38,13 +39,13 @@
 #define PAM_BAD_ITEM PAM_SYMBOL_ERR
 #endif
 
-static const char pw[] = "0123456789";
+static PAM_CONST char pw[] = "0123456789";
 static char *response = "";
 static void *pam_module;
 static enum { TWO_PROMPTS, COMBINED_PASSWORD, COMBINED_PROMPT } conv_mode;
 static int num_prompts_shown = 0;
 
-static int conversation(int num_msg, const struct pam_message **msg,
+static int conversation(int num_msg, PAM_CONST struct pam_message **msg,
                         struct pam_response **resp, void *appdata_ptr) {
   // Keep track of how often the conversation callback is executed.
   ++num_prompts_shown;
@@ -63,11 +64,6 @@ static int conversation(int num_msg, const struct pam_message **msg,
   return PAM_CONV_ERR;
 }
 
-#ifdef sun
-#define PAM_CONST
-#else
-#define PAM_CONST const
-#endif
 int pam_get_item(const pam_handle_t *pamh, int item_type,
                  PAM_CONST void **item)
   __attribute__((visibility("default")));
@@ -105,10 +101,10 @@ int pam_get_item(const pam_handle_t *pamh, int item_type,
 }
 
 int pam_set_item(pam_handle_t *pamh, int item_type,
-                 PAM_CONST void *item)
+                 const void *item)
   __attribute__((visibility("default")));
 int pam_set_item(pam_handle_t *pamh, int item_type,
-                 PAM_CONST void *item) {
+                 const void *item) {
   switch (item_type) {
     case PAM_AUTHTOK:
       if (strcmp((char *)item, pw)) {


### PR DESCRIPTION
Since Solaris-derived systems and Linux have a few differences on what things should and shouldn't be const, this should detect and adjust correctly (so no warnings are generated).

It also fixes the issue where the wrong getpw*_r() prototypes are getting included -- enabling the system extensions in configure.ac defines the correct flags (as well as _GNU_SOURCE).

On Solaris 11.2 this now builds cleanly, with no warnings.