### PR TITLE
Support for .dylib in addition to .so

### DIFF
--- a/libpam/google-authenticator.c
+++ b/libpam/google-authenticator.c
@@ -207,6 +207,9 @@ static void displayQRCode(const char *secret, const char *label,
     if (!qrencode) {
       qrencode = dlopen("libqrencode.so.3", RTLD_NOW | RTLD_LOCAL);
     }
+    if (!qrencode) {
+      qrencode = dlopen("libqrencode.dylib.3", RTLD_NOW | RTLD_LOCAL);
+    }
     if (qrencode) {
       typedef struct {
         int version;


### PR DESCRIPTION
Mac OS X uses a .dylib naming convention for dynamic libraries.
This patch allows library built on Mac OS X to support qrencode.