### PR TITLE
Add a resync window, allow for longer codes to be used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ libpam/Makefile
 libpam/Makefile.in
 libpam/aclocal.m4
 libpam/autom4te.cache/
+libpam/base32
 libpam/compile
 libpam/config.guess
 libpam/config.h

--- a/libpam/FILEFORMAT
+++ b/libpam/FILEFORMAT
@@ -6,7 +6,9 @@ The file size is currently limited to 1kB. This should be generous even
 when using a very large list of scratch codes.
 
 The first line is the base32 encoded secret. It uses characters in the range
-A..Z2..7.
+A..Z2..7.  The secret is used after first trying any one-time scratch codes.
+HOTP mode is used only if HOTP_COUNTER is present.
+TOTP mode is used only if TOTP_AUTH is present *and* HOTP_COUNTER is not present.
 
 The following lines are optional. They all start with a double quote character,
 followed by a space character. Followed by an option name. Option names are
@@ -37,6 +39,10 @@ Currently, the following options are recognized:
     the presence of this option indicates that the secret can be used to
     authenticate users with a time-based token.
 
+  STEP_SIZE
+    the number of seconds in each time step during which a TOTP code is valid.
+    The default is that a code is valid for 30 seconds.
+
   HOTP_COUNTER n
     the presence of this option indicates that the secret can be used to
     authenticate users with a counter-based token.  The argument "n"
@@ -56,7 +62,7 @@ Currently, the following options are recognized:
 
 
 Any all-numeric sequence of eight-digit numbers are randomly generated
-one-time tokens. The user can enter any arbitrary one-time code
+one-time scratch code tokens. The user can enter any arbitrary one-time code
 to log into his account. The code will then be removed from the file.
 
 

--- a/libpam/FILEFORMAT
+++ b/libpam/FILEFORMAT
@@ -60,10 +60,19 @@ Currently, the following options are recognized:
     for most users as invalid login attempts and generated-but-not-used
     tokens both contribute to synchronization problems.
 
+  RWINDOW_SIZE n
+    when set, this enables a resynchronization window for HOTP mode during
+    which two, valid, consecutive codes used one right after the other will be
+    considered to be a successful authentication, even when beyond the limit
+    set by WINDOW_SIZE.
+    Setting this to anything less than WINDOW_SIZE + 2 will have no effect.
+
+  _LAST_VALID_CODE_COUNTER
+    an internal option used to track the first valid code of a resynchronization
+    sequence.  This should not be modified, but may be deleted at will.
 
 Any all-numeric sequence of eight-digit numbers are randomly generated
 one-time scratch code tokens. The user can enter any arbitrary one-time code
 to log into his account. The code will then be removed from the file.
 
 
-  

--- a/libpam/FILEFORMAT
+++ b/libpam/FILEFORMAT
@@ -60,12 +60,16 @@ Currently, the following options are recognized:
     for most users as invalid login attempts and generated-but-not-used
     tokens both contribute to synchronization problems.
 
+    If not specified, the default_window_size PAM config option is used.
+
   RWINDOW_SIZE n
     when set, this enables a resynchronization window for HOTP mode during
     which two, valid, consecutive codes used one right after the other will be
     considered to be a successful authentication, even when beyond the limit
     set by WINDOW_SIZE.
     Setting this to anything less than WINDOW_SIZE + 2 will have no effect.
+
+    If not specified, the default_rwindow_size PAM config option is used.
 
   _LAST_VALID_CODE_COUNTER
     an internal option used to track the first valid code of a resynchronization

--- a/libpam/Makefile.am
+++ b/libpam/Makefile.am
@@ -1,6 +1,6 @@
 pamdir = $(libdir)/security
 
-bin_PROGRAMS=google-authenticator
+bin_PROGRAMS=google-authenticator base32
 pam_LTLIBRARIES=pam_google_authenticator.la
 noinst_PROGRAMS=demo pam_google_authenticator_unittest
 check_LTLIBRARIES=libpam_google_authenticator_testing.la
@@ -30,7 +30,12 @@ hmac.h \
 sha1.c \
 sha1.h
 
-TESTS=pam_google_authenticator_unittest
+base32_SOURCES=\
+base32_prog.c \
+base32.c \
+base32.h
+
+TESTS=pam_google_authenticator_unittest base32_test.sh
 pam_google_authenticator_unittest_SOURCES=\
 pam_google_authenticator_unittest.c \
 base32.c \

--- a/libpam/README.md
+++ b/libpam/README.md
@@ -140,3 +140,11 @@ timebased, use the `google-authenticator` binary to generate a secret key in
 your home directory with the proper option.  In this mode, clock skew is
 irrelevant and the window size option now applies to how many codes beyond the
 current one that would be accepted, to reduce synchronization problems.
+
+### otp_length
+
+Many tokens can be configured to use longer HOTP/TOTP codes, up to 9 digits.
+Valid values are in the range 6-9.  The default if not specified is 6.
+Setting this option will change the code length for all users.
+It is not currently possible to set this on a user-by-user basis.
+

--- a/libpam/README.md
+++ b/libpam/README.md
@@ -148,3 +148,13 @@ Valid values are in the range 6-9.  The default if not specified is 6.
 Setting this option will change the code length for all users.
 It is not currently possible to set this on a user-by-user basis.
 
+### show_counter_in_prompt
+
+Show the current HOTP counter value, if any is available, in the prompt
+displayed to the user.  Note that this will slightly decrease the security
+of the token, since an attacker will only need to guess the shared secret
+and not also the counter value.  Assuming shared secrets of at least 20 bytes,
+the impact of knowing the few bits of state from the counter are likely to be
+minimal.  Of more concern may be that an attacker will be able to detect when
+the real user logs in.
+

--- a/libpam/README.md
+++ b/libpam/README.md
@@ -121,8 +121,9 @@ to disable it, you can do so on the module command line:
 
 ### no_increment_hotp
 
-Don't increment the counter for failed HOTP attempts. This is important if log
-attempts with failed passwords still get an OTP prompt.
+Don't increment the counter for failed HOTP attempts.  Normally you should set
+this so failed password attempts by an attacker without a token don't lock out
+the authorized user.
 
 ### nullok
 

--- a/libpam/README.md
+++ b/libpam/README.md
@@ -159,3 +159,9 @@ the impact of knowing the few bits of state from the counter are likely to be
 minimal.  Of more concern may be that an attacker will be able to detect when
 the real user logs in.
 
+### default_window_size / default_rwindow_size
+
+Default values for the WINDOW_SIZE and RWINDOW_SIZE options.  This may be
+overridden by corresponding values in individual user's .google_authenticator
+files.
+

--- a/libpam/autoconf-archive/README.txt
+++ b/libpam/autoconf-archive/README.txt
@@ -1,0 +1,21 @@
+
+# This contains a few extra macros from the Autoconf Archive.
+# It was populated with:
+
+ACAVER=autoconf-archive-2015.09.25
+[ -e "${ACAVER}.tar.xz" ] || \
+curl -O "http://gnu.mirror.iweb.com/autoconf-archive/${ACAVER}".tar.xz
+xz -c -d "${ACAVER}".tar.xz | tar xf -
+M4FILES="
+	ax_append_compile_flags.m4
+	ax_append_flag.m4
+	ax_check_compile_flag.m4
+	ax_require_defined.m4
+"
+
+mkdir -p autoconf-archive/m4
+for m in $M4FILES ; do
+	cp "${ACAVER}/m4/$m" autoconf-archive/m4/.
+done
+
+git add autoconf-archive

--- a/libpam/autoconf-archive/m4/ax_append_compile_flags.m4
+++ b/libpam/autoconf-archive/m4/ax_append_compile_flags.m4
@@ -1,0 +1,65 @@
+# ===========================================================================
+#  http://www.gnu.org/software/autoconf-archive/ax_append_compile_flags.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_COMPILE_FLAGS([FLAG1 FLAG2 ...], [FLAGS-VARIABLE], [EXTRA-FLAGS])
+#
+# DESCRIPTION
+#
+#   For every FLAG1, FLAG2 it is checked whether the compiler works with the
+#   flag.  If it does, the flag is added FLAGS-VARIABLE
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  During the check the flag is always added to the
+#   current language's flags.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   NOTE: This macro depends on the AX_APPEND_FLAG and
+#   AX_CHECK_COMPILE_FLAG. Please keep this macro in sync with
+#   AX_APPEND_LINK_FLAGS.
+#
+# LICENSE
+#
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 4
+
+AC_DEFUN([AX_APPEND_COMPILE_FLAGS],
+[AX_REQUIRE_DEFINED([AX_CHECK_COMPILE_FLAG])
+AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
+for flag in $1; do
+  AX_CHECK_COMPILE_FLAG([$flag], [AX_APPEND_FLAG([$flag], [$2])], [], [$3])
+done
+])dnl AX_APPEND_COMPILE_FLAGS

--- a/libpam/autoconf-archive/m4/ax_append_flag.m4
+++ b/libpam/autoconf-archive/m4/ax_append_flag.m4
@@ -1,0 +1,71 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_append_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_FLAG(FLAG, [FLAGS-VARIABLE])
+#
+# DESCRIPTION
+#
+#   FLAG is appended to the FLAGS-VARIABLE shell variable, with a space
+#   added in between.
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  FLAGS-VARIABLE is not changed if it already contains
+#   FLAG.  If FLAGS-VARIABLE is unset in the shell, it is set to exactly
+#   FLAG.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 6
+
+AC_DEFUN([AX_APPEND_FLAG],
+[dnl
+AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_SET_IF
+AS_VAR_PUSHDEF([FLAGS], [m4_default($2,_AC_LANG_PREFIX[FLAGS])])
+AS_VAR_SET_IF(FLAGS,[
+  AS_CASE([" AS_VAR_GET(FLAGS) "],
+    [*" $1 "*], [AC_RUN_LOG([: FLAGS already contains $1])],
+    [
+     AS_VAR_APPEND(FLAGS,[" $1"])
+     AC_RUN_LOG([: FLAGS="$FLAGS"])
+    ])
+  ],
+  [
+  AS_VAR_SET(FLAGS,[$1])
+  AC_RUN_LOG([: FLAGS="$FLAGS"])
+  ])
+AS_VAR_POPDEF([FLAGS])dnl
+])dnl AX_APPEND_FLAG

--- a/libpam/autoconf-archive/m4/ax_check_compile_flag.m4
+++ b/libpam/autoconf-archive/m4/ax_check_compile_flag.m4
@@ -1,0 +1,74 @@
+# ===========================================================================
+#   http://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 4
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/libpam/autoconf-archive/m4/ax_require_defined.m4
+++ b/libpam/autoconf-archive/m4/ax_require_defined.m4
@@ -1,0 +1,37 @@
+# ===========================================================================
+#    http://www.gnu.org/software/autoconf-archive/ax_require_defined.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_REQUIRE_DEFINED(MACRO)
+#
+# DESCRIPTION
+#
+#   AX_REQUIRE_DEFINED is a simple helper for making sure other macros have
+#   been defined and thus are available for use.  This avoids random issues
+#   where a macro isn't expanded.  Instead the configure script emits a
+#   non-fatal:
+#
+#     ./configure: line 1673: AX_CFLAGS_WARN_ALL: command not found
+#
+#   It's like AC_REQUIRE except it doesn't expand the required macro.
+#
+#   Here's an example:
+#
+#     AX_REQUIRE_DEFINED([AX_CHECK_LINK_FLAG])
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 1
+
+AC_DEFUN([AX_REQUIRE_DEFINED], [dnl
+  m4_ifndef([$1], [m4_fatal([macro ]$1[ is not defined; is a m4 file missing?])])
+])dnl AX_REQUIRE_DEFINED

--- a/libpam/base32.h
+++ b/libpam/base32.h
@@ -33,7 +33,7 @@
 int base32_decode(const uint8_t *encoded, uint8_t *result, int bufSize)
     __attribute__((visibility("hidden")));
 int base32_encode(const uint8_t *data, int length, uint8_t *result,
-                  int bufSize)
+                  int bufSize, int pad)
     __attribute__((visibility("hidden")));
 
 #endif /* _BASE32_H_ */

--- a/libpam/base32_prog.c
+++ b/libpam/base32_prog.c
@@ -1,0 +1,178 @@
+// Base32 utility program
+//
+// Copyright 2015 TWO SIGMA OPEN SOURCE, LLC
+// Author: Eric Haszlakiewicz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include "base32.h"
+
+/*
+ * Convert arbitrary input from a file to base-32 encoded output on stdout.
+ * Decode base-32 input from a file or from the command line to arbitrary
+ * output on stdout.
+ *
+ * ~/google-authenticator/libpam/base32 e $(awk '{ print $2 }' < gauth.seed | xxd -r -p)
+ */
+
+enum modes {
+	ENCODE_NONE = 0,
+	ENCODE_FILE = 1,
+	DECODE_FILE = 2,
+	DECODE_STRING = 3,
+};
+
+static void usage(const char *argv0, int exitval, char *errmsg) __attribute__((noreturn));
+static void usage(const char *argv0, int exitval, char *errmsg)
+{
+	FILE *f = stdout;
+	if (errmsg) {
+		fprintf(stderr, "ERROR: %s\n", errmsg);
+		f = stderr;
+	}
+	
+	fprintf(f, "Usage: %s -e [<file>]\n", argv0);
+	fprintf(f, "Usage: %s -d [<file>]\n", argv0);
+	fprintf(f, "Usage: %s -D <value>\n", argv0);
+	fprintf(f, "  Emits <value> encoded in/decoded from base-32 on stdout.\n");
+	fprintf(f, "  When encoding, the file should contain raw binary data.\n");
+	fprintf(f, "   If no filename is specified, it reads from stdin.\n");
+	fprintf(f, "  All output is written to stdout.\n");
+
+	exit(exitval);
+}
+
+/* Write the full contents of buf to the given file descriptor,
+ * even across multiple short writes.
+ * If write() fails, exit with an error.
+ */
+static void full_write(int fd, uint8_t *buf, size_t remaining);
+static void full_write(int fd, uint8_t *buf, size_t remaining)
+{
+	ssize_t offset, written;
+	for (offset = 0; remaining != 0; remaining -= written, offset += written)
+		if ((written = write(fd, buf + offset, remaining)) < 0)
+			err(1, "Failed to write to stdout");
+}
+
+int main(int argc, char *argv[]) {
+	int c;
+	int mode = ENCODE_NONE;
+	while ((c = getopt(argc, argv, "edDh")) != -1) {
+		switch (c) {
+		case 'e':
+			mode = ENCODE_FILE;
+			break;
+		case 'd':
+			mode = DECODE_FILE;
+			break;
+		case 'D':
+			mode = DECODE_STRING;
+			break;
+		case 'h':
+			usage(argv[0], 0, NULL);
+			break;
+		default:
+			usage(argv[0], 1, "Unknown command line argument");
+			break;
+		}
+	}
+
+	if (mode == ENCODE_NONE) {
+		usage(argv[0], 1, "A mode of operation must be chosen.");
+	}
+
+	int retval;
+	if (mode == ENCODE_FILE || mode == DECODE_FILE) {
+		if (argc - optind > 1) {
+			usage(argv[0], 1, "Too many args");
+		}
+
+		const char *binfile = (optind < argc) ? argv[optind] : "-";
+		int d = strcmp(binfile, "-") == 0 ? STDIN_FILENO : open(binfile, O_RDONLY);
+		if (d < 0) {
+			err(1, "Failed to open %s: %s\n", binfile, strerror(errno));
+		}
+		struct stat st;
+		memset(&st, 0, sizeof(st));
+		if (fstat(d, &st) < 0 || st.st_size == 0) {
+			st.st_size = 5 * 1024;  // multiple of 5 to avoid internal padding
+			                        // AND multiple of 8 to ensure we feed
+			                        //  valid data to base32_decode().
+		}
+		uint8_t *input = malloc(st.st_size + 1);
+		int amt_read;
+		int amt_to_read = st.st_size;
+		errno = 0;
+		while ((amt_read = read(d, input, amt_to_read)) > 0 || errno == EINTR) {
+			if (errno == EINTR) {
+				continue;
+			}
+
+			// Encoding: 8 bytes out for every 5 input, plus up to 6 padding, and nul
+			// Decoding: up to 5 bytes out for every 8 input.
+			int result_avail = (mode == ENCODE_FILE) ?
+			                     ((amt_read + 4) / 5 * 8 + 6 + 1) :
+			                     ((amt_read + 7) / 8 * 5) ;
+			uint8_t *result = malloc(result_avail);
+
+			input[amt_read] = '\0';
+
+			if (mode == ENCODE_FILE) {
+				retval = base32_encode(input, amt_read, result, result_avail, 1);
+			} else {
+				retval = base32_decode(input, result, result_avail);
+			}
+			if (retval < 0) {
+				fprintf(stderr, "%s failed.  Input too long?\n", (mode == ENCODE_FILE) ? "base32_encode" : "base32_decode");
+				exit(1);
+			}
+			//printf("%s", result);
+			full_write(STDOUT_FILENO, result, retval);
+			fflush(stdout);
+			free(result);
+		}
+		if (amt_read < 0) {
+			err(1, "Failed to read from %s: %s\n", binfile, strerror(errno));
+		}
+		if (mode == ENCODE_FILE) {
+			printf("\n");
+		}
+	} else { // mode == DECODE_STRING
+		if (argc - optind < 1) {
+			usage(argv[0], 1, "Not enough args");
+		}
+
+		const char *base32_value = argv[2];
+		int result_avail = strlen(base32_value) + 1;
+		uint8_t *result = malloc(result_avail);
+
+		retval = base32_decode((uint8_t *)base32_value, result, result_avail);
+		if (retval < 0) {
+			fprintf(stderr, "base32_decode failed.  Input too long?\n");
+			exit(1);
+		}
+		full_write(STDOUT_FILENO, result, retval);
+	}
+	return 0;
+}

--- a/libpam/base32_test.sh
+++ b/libpam/base32_test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+a=0
+while [ $a -lt 150 ] ;do
+	dd if=/dev/urandom bs=$RANDOM count=1 of=testfile > /dev/null 2>&1
+	cat testfile | ./base32 -e | ./base32 -d > testfile.out
+	if ! cmp -s testfile testfile.out ; then
+		echo FAILED
+		exit 1
+	fi
+	a=$((a + 1))
+done
+
+rm testfile testfile.out

--- a/libpam/bootstrap.sh
+++ b/libpam/bootstrap.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-exec autoreconf -i
+mkdir -p m4  # some versions of autoconf insist on this being present
+exec autoreconf -i -Iautoconf-archive/m4

--- a/libpam/configure.ac
+++ b/libpam/configure.ac
@@ -11,6 +11,16 @@ AC_CONFIG_HEADER(config.h)
 AC_PROG_CC
 AC_PROG_CC_STDC
 
+AX_APPEND_COMPILE_FLAGS([-Wall -fstack-protector])
+AC_ARG_ENABLE([Werror],
+    [AS_HELP_STRING([--enable-Werror], [Enable passing of -Werror, if your compiler supports it])],
+    [],
+    [enable_Werror=no])
+
+AS_IF([test "x$enable_Werror" = "xyes"], [
+AX_APPEND_COMPILE_FLAGS([-Werror])
+])
+
 AC_CHECK_HEADERS([sys/fsuid.h])
 AC_CHECK_FUNCS([setfsuid])
 

--- a/libpam/demo.c
+++ b/libpam/demo.c
@@ -88,17 +88,16 @@ int pam_get_item(const pam_handle_t *pamh, int item_type,
   switch (item_type) {
     case PAM_SERVICE: {
       static const char service[] = "google_authenticator_demo";
-      memcpy(item, &service, sizeof(&service));
+      *item = service;
       return PAM_SUCCESS;
     }
     case PAM_USER: {
-      char *user = getenv("USER");
-      memcpy(item, &user, sizeof(&user));
+      *item = getenv("USER");
       return PAM_SUCCESS;
     }
     case PAM_CONV: {
       static struct pam_conv conv = { .conv = conversation }, *p_conv = &conv;
-      memcpy(item, &p_conv, sizeof(p_conv));
+      *item = p_conv;
       return PAM_SUCCESS;
     }
     default:

--- a/libpam/google-authenticator.c
+++ b/libpam/google-authenticator.c
@@ -742,7 +742,7 @@ int main(int argc, char *argv[]) {
   if (!force) {
     printf("\nDo you want me to update your \"%s\" file (y/n) ", secret_fn);
     fflush(stdout);
-    char ch;
+    int ch;
     do {
       ch = getchar();
     } while (ch == ' ' || ch == '\r' || ch == '\n');

--- a/libpam/google-authenticator.c
+++ b/libpam/google-authenticator.c
@@ -678,7 +678,7 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  base32_encode(buf, SECRET_BITS/8, (uint8_t *)secret, sizeof(secret));
+  base32_encode(buf, SECRET_BITS/8, (uint8_t *)secret, sizeof(secret), 0);
   int use_totp;
   if (mode == ASK_MODE) {
     use_totp = maybe("Do you want authentication tokens to be time-based");

--- a/libpam/hmac.c
+++ b/libpam/hmac.c
@@ -41,7 +41,9 @@ void hmac_sha1(const uint8_t *key, int keyLength,
   for (int i = 0; i < keyLength; ++i) {
     tmp_key[i] = key[i] ^ 0x36;
   }
-  memset(tmp_key + keyLength, 0x36, 64 - keyLength);
+  if (keyLength < 64) {
+    memset(tmp_key + keyLength, 0x36, 64 - keyLength);
+  }
 
   // Compute inner digest
   sha1_init(&ctx);

--- a/libpam/pam_google_authenticator.c
+++ b/libpam/pam_google_authenticator.c
@@ -226,7 +226,7 @@ static char *get_secret_filename(pam_handle_t *pamh, const Params *params,
     if (var) {
       size_t subst_len = strlen(subst);
       char *resized = realloc(secret_filename,
-                              strlen(secret_filename) + subst_len);
+                              strlen(secret_filename) + subst_len + 1);
       if (!resized) {
         goto err;
       }
@@ -699,8 +699,8 @@ static int set_cfg_value(pam_handle_t *pamh, SecretFile *secfile,
     memcpy(resized, secfile->secret_buf, start - secfile->secret_buf);
     memcpy(resized + (start - secfile->secret_buf) + total_len, stop, tail_len + 1);
     memset(secfile->secret_buf, 0, buf_len);
-    free(secfile->secret_buf);
     start = start - secfile->secret_buf + resized;
+    free(secfile->secret_buf);
     secfile->secret_buf = resized;
   }
 
@@ -1577,7 +1577,6 @@ static int parse_args(pam_handle_t *pamh, int argc, const char **argv,
   int rc;
   for (int i = 0; i < argc; ++i) {
     if (!memcmp(argv[i], "secret=", 7)) {
-      free((void *)params->secret_filename_spec);
       params->secret_filename_spec = argv[i] + 7;
     } else if (!memcmp(argv[i], "user=", 5)) {
       uid_t uid;

--- a/libpam/pam_google_authenticator_unittest.c
+++ b/libpam/pam_google_authenticator_unittest.c
@@ -139,7 +139,7 @@ int main(int argc, char *argv[]) {
   puts("Testing base32 encoding");
   static const uint8_t dat[] = "Hello world...";
   uint8_t enc[((sizeof(dat) + 4)/5)*8 + 1];
-  assert(base32_encode(dat, sizeof(dat), enc, sizeof(enc)) == sizeof(enc)-1);
+  assert(base32_encode(dat, sizeof(dat), enc, sizeof(enc), 0) == sizeof(enc)-1);
   assert(!strcmp((char *)enc, "JBSWY3DPEB3W64TMMQXC4LQA"));
  
   puts("Testing base32 decoding");

--- a/libpam/pam_google_authenticator_unittest.c
+++ b/libpam/pam_google_authenticator_unittest.c
@@ -213,8 +213,8 @@ int main(int argc, char *argv[]) {
   void (*set_time)(time_t t) =
       (void (*)(time_t))dlsym(pam_module, "set_time");
   assert(set_time);
-  int (*compute_code)(uint8_t *, int, unsigned long) =
-      (int (*)(uint8_t*, int, unsigned long))dlsym(pam_module, "compute_code");
+  uint32_t (*compute_code)(const uint8_t *, int, unsigned long, int) =
+      (uint32_t (*)(const uint8_t*, int, unsigned long, int))dlsym(pam_module, "compute_code");
   assert(compute_code);
 
   for (int otp_mode = 0; otp_mode < 8; ++otp_mode) {
@@ -424,7 +424,7 @@ int main(int argc, char *argv[]) {
       char buf[7];
       response = buf;
       sprintf(response, "%06d", compute_code(binary_secret,
-                                             binary_secret_len, i));
+                                             binary_secret_len, i, 6));
       assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_SUCCESS);
       verify_prompts_shown(expected_good_prompts_shown);
     }
@@ -453,7 +453,7 @@ int main(int argc, char *argv[]) {
       char buf[7];
       response = buf;
       sprintf(response, "%06d",
-              compute_code(binary_secret, binary_secret_len, *tm++));
+              compute_code(binary_secret, binary_secret_len, *tm++, 6));
       assert(pam_sm_authenticate(NULL, 0, targc, targv) == *res);
       verify_prompts_shown(
           *res != PAM_SUCCESS ? 0 : expected_good_prompts_shown);
@@ -496,7 +496,7 @@ int main(int argc, char *argv[]) {
       char buf[7];
       response = buf;
       sprintf(response, "%06d",
-              compute_code(binary_secret, binary_secret_len, 11000 + i));
+              compute_code(binary_secret, binary_secret_len, 11000 + i, 6));
       assert(pam_sm_authenticate(NULL, 0, targc, targv) ==
              (i >= 2 ? PAM_SUCCESS : PAM_AUTH_ERR));
       verify_prompts_shown(expected_good_prompts_shown);
@@ -505,7 +505,7 @@ int main(int argc, char *argv[]) {
     char buf[7];
     response = buf;
     sprintf(response, "%06d", compute_code(binary_secret,
-                                           binary_secret_len, 11010));
+                                           binary_secret_len, 11010, 6));
     assert(pam_sm_authenticate(NULL, 0, 1,
                                (const char *[]){ "noskewadj", 0 }) ==
            PAM_AUTH_ERR);

--- a/libpam/pam_google_authenticator_unittest.c
+++ b/libpam/pam_google_authenticator_unittest.c
@@ -72,17 +72,16 @@ int pam_get_item(const pam_handle_t *pamh, int item_type,
   switch (item_type) {
     case PAM_SERVICE: {
       static const char *service = "google_authenticator_unittest";
-      memcpy(item, &service, sizeof(&service));
+      *item = service;
       return PAM_SUCCESS;
     }
     case PAM_USER: {
-      char *user = getenv("USER");
-      memcpy(item, &user, sizeof(&user));
+      *item = getenv("USER");
       return PAM_SUCCESS;
     }
     case PAM_CONV: {
       static struct pam_conv conv = { .conv = conversation }, *p_conv = &conv;
-      memcpy(item, &p_conv, sizeof(p_conv));
+      *item = p_conv;
       return PAM_SUCCESS;
     }
     case PAM_AUTHTOK: {
@@ -220,7 +219,9 @@ int main(int argc, char *argv[]) {
   for (int otp_mode = 0; otp_mode < 8; ++otp_mode) {
     // Create a secret file with a well-known test vector
     char fn[] = "/tmp/.google_authenticator_XXXXXX";
+    mode_t orig_umask = umask(S_IRWXG|S_IRWXO); // Only for the current user
     int fd = mkstemp(fn);
+    (void)umask(orig_umask);
     assert(fd >= 0);
     static const uint8_t secret[] = "2SH3V3GDW7ZNMGYE";
     assert(write(fd, secret, sizeof(secret)-1) == sizeof(secret)-1);


### PR DESCRIPTION
The main changes in this pull request are to add a resync window and to allow for longer codes to be used (configurable through a PAM option).
In addition to that, some of the other commits include:
- Add PAM options for window sizes.
- Add a base32 utility program, and support for padding when encoding and decoding.
- A few other changes, including addressing potential bugs found through static anlysis and turning on addition compiler warnings.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/google-authenticator/525)

<!-- Reviewable:end -->
