### PR TITLE
libpam/demo: fix overflow in code input

### DIFF
--- a/libpam/demo.c
+++ b/libpam/demo.c
@@ -49,7 +49,7 @@ static int conversation(int num_msg, PAM_CONST struct pam_message **msg,
        msg[0]->msg_style == PAM_PROMPT_ECHO_ON)) {
     *resp = malloc(sizeof(struct pam_response));
     assert(*resp);
-    (*resp)->resp = calloc(1024, 0);
+    (*resp)->resp = calloc(1024, 1);
     struct termios termios = old_termios;
     if (msg[0]->msg_style == PAM_PROMPT_ECHO_OFF) {
       termios.c_lflag &= ~(ECHO|ECHONL);


### PR DESCRIPTION
Correct an incorrect allocation resulting in an overflow of the response
buffer:

$ ./demo
Verification code: 0123456789012345678901234567890
*** Error in `./demo': malloc(): memory corruption: 0x00000000025300e0 ***