### PR TITLE
Allow reduction of PAM restrictions

### DIFF
--- a/libpam/README.md
+++ b/libpam/README.md
@@ -73,19 +73,22 @@ this location.
 In addition to "${USER}", the `secret=` option also recognizes both "~" and
 `${HOME}` as short-hands for the user's home directory.
 
-When using the `secret=` option, you might want to also set the `user=`
-option. The latter forces the PAM module to switch to a dedicated hard-coded
-user id prior to doing any file operations. When using the `user=` option, you
-must not include "~" or "${HOME}" in the filename.
+When using the `secret=` option, you might want to also set the `user=` option.
+When using the `user=` option, you must not include "~" or "${HOME}" in the filename.
 
 The `user=` option can also be useful if you want to authenticate users who do
 not have traditional UNIX accounts on your system.
 
 ## Module options
 
-### secret=/path/to/secret/file / user=some-user
+### secret=/path/to/secret/file
 
 See "encrypted home directories", above.
+
+### user=some-user
+
+Force the PAM module to switch to a hard-coded user id prior to doing
+any file operations
 
 ### debug
 
@@ -140,3 +143,11 @@ timebased, use the `google-authenticator` binary to generate a secret key in
 your home directory with the proper option.  In this mode, clock skew is
 irrelevant and the window size option now applies to how many codes beyond the
 current one that would be accepted, to reduce synchronization problems.
+
+## allow_perm
+
+By default, the PAM module requires the secrets file to be readable only by the owner of the file ( 0400 by default). In situations where the module is not used in a non-default configuration, an administrator may need more leanient file permissions, or a specific setting for their use case.
+
+## no_strict_owner
+
+By default, the PAM module requires the secrets file must be owned but PAM user. The PAM user will default to the user being authenticated, or a static user if the `user=` option is used.

--- a/libpam/configure.ac
+++ b/libpam/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.61)
-AC_INIT(google-authenticator, 1.01, habets@google.com)
+AC_INIT(google-authenticator, 1.02, habets@google.com)
 AC_USE_SYSTEM_EXTENSIONS
 LT_INIT
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
The commits in this PR implement 2 options for the PAM module:
- no_strict_owner
- allow_perm=<perm_octal>

These options are documented in the PR, but are intended for use in situations where the user secret files are stored outside the home directory (usually all in the same directory).
The expectation when using these options is that administrators will consider the risks associated with the requirements of this configuration (such as sticky-it requirements, etc).

These scenario that inspired this is the following:
 - 2 servers running radius servers
 - both servers should support 2FA
 - radius processes should not run as root

The configuration that we came to for synchronizing the google-authenticator files was to have them in their own separate directory (eg /var/spool/google-authenticator/${USER}.secret).
This allowed us to have the radius service run as an unprivileged service, and users are not able to interfere with each other's files due to default ACLs applied and sticky-bit settings on the folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/google-authenticator/542)
<!-- Reviewable:end -->
