### PR TITLE
update to _DEFAULT_SOURCE for newer glibc

### DIFF
--- a/libpam/sha1.c
+++ b/libpam/sha1.c
@@ -41,6 +41,7 @@
  *****************************************************************************
 */
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #include <sys/types.h> // Defines BYTE_ORDER, iff _BSD_SOURCE is defined
 #include <string.h>
 


### PR DESCRIPTION
The _BSD_SOURCE define is deprecated in glibc and has been replaced with
_DEFAULT_SOURCE.  If the old define is used, then you get a build time
warning.  Define both to work with old & new versions of glibc.