### PR TITLE
move demo/tests to check phase

### DIFF
--- a/libpam/Makefile.am
+++ b/libpam/Makefile.am
@@ -2,7 +2,7 @@ pamdir = $(libdir)/security
 
 bin_PROGRAMS=google-authenticator
 pam_LTLIBRARIES=pam_google_authenticator.la
-noinst_PROGRAMS=demo pam_google_authenticator_unittest
+check_PROGRAMS=demo pam_google_authenticator_unittest
 check_LTLIBRARIES=libpam_google_authenticator_testing.la
 
 dist_doc_DATA = FILEFORMAT README.md


### PR DESCRIPTION
These programs don't need to be built every time you run `make`.
Move them to the check phase so they'll be built when you run
with `make check`.  Or `make demo`.