### PR TITLE
Increase secret bits from 80 -> 128

### DIFF
--- a/libpam/src/google-authenticator.c
+++ b/libpam/src/google-authenticator.c
@@ -36,7 +36,7 @@
 #include "sha1.h"
 
 #define SECRET                    "/.google_authenticator"
-#define SECRET_BITS               80          // Must be divisible by eight
+#define SECRET_BITS               128         // Must be divisible by eight
 #define VERIFICATION_CODE_MODULUS (1000*1000) // Six digits
 #define SCRATCHCODES              5           // Number of initial scratchcodes
 #define SCRATCHCODE_LENGTH        8           // Eight digits per scratchcode


### PR DESCRIPTION
Reasons:

- This makes it RFC compliant (some HOTP/TOTP implementations reject short keys)
- Increases security to a more "standard" size

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/google-authenticator/556)
<!-- Reviewable:end -->
