### PR TITLE
Added authtok_prompt argument support

### DIFF
--- a/libpam/README.md
+++ b/libpam/README.md
@@ -87,6 +87,13 @@ not have traditional UNIX accounts on your system.
 
 See "encrypted home directories", above.
 
+### authtok_prompt=prompt
+
+Overrides default token prompt. If you want to include spaces in the prompt,
+wrap the whole argument in square brackets:
+
+`  auth required pam_google_authenticator.so [authtok_prompt=Your secret token: ]`
+
 ### user=some-user
 
 Force the PAM module to switch to a hard-coded user id prior to doing any file


### PR DESCRIPTION
This pull requests adds `authtok_prompt` argument support. This will allow system administrators to change token prompt (critical in case when there are multiple corporate network with different tokens).

Usage:

    auth required pam_google_authenticator.so [authtok_prompt=Your secret token: ]

Argument name was chosen to conform [freebsd documentation for pam.d](https://www.freebsd.org/cgi/man.cgi?query=pam.d&sektion=5#MODULE_OPTIONS).

Please note the use of square brackets. According to pam.d documentation:

> module-arguments are a space separated list of tokens that can be used to modify the specific behavior of the given PAM. Such arguments will be documented for each individual module. Note, if you wish to include spaces in an argument, you should surround that argument with square brackets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/google-authenticator/573)
<!-- Reviewable:end -->
