### PR TITLE
#652 Support padding for Base32 encoded secrets on iOS

### DIFF
--- a/mobile/ios/Classes/OTPAuthURL.m
+++ b/mobile/ios/Classes/OTPAuthURL.m
@@ -186,6 +186,8 @@ NSString *const OTPAuthURLSecondsBeforeNewOTPKey
     [GTMStringEncoding stringEncodingWithString:kBase32Charset];
   [coder addDecodeSynonyms:kBase32Synonyms];
   [coder ignoreCharacters:kBase32Sep];
+  [coder setPaddingChar:'=']
+  [coder setDoPad:YES];
   return [coder decode:string];
 }
 
@@ -194,6 +196,8 @@ NSString *const OTPAuthURLSecondsBeforeNewOTPKey
     [GTMStringEncoding stringEncodingWithString:kBase32Charset];
   [coder addDecodeSynonyms:kBase32Synonyms];
   [coder ignoreCharacters:kBase32Sep];
+  [coder setPaddingChar:'=']
+  [coder setDoPad:YES];
   return [coder encode:data];
 }
 


### PR DESCRIPTION
Support padding for Base32 encoded secrets on iOS as specified in https://tools.ietf.org/html/rfc4648#section-3.2